### PR TITLE
fix: DiseaseDescriptor.disease --> DiseaseDescriptor.disease_id (main)

### DIFF
--- a/disease/query.py
+++ b/disease/query.py
@@ -315,7 +315,7 @@ class QueryHandler:
         """
         sources_meta = {}
         vod = response['disease_descriptor']
-        ids = [vod['disease']] + vod.get('xrefs', [])
+        ids = [vod['disease_id']] + vod.get('xrefs', [])
         for concept_id in ids:
             prefix = concept_id.split(':')[0]
             src_name = PREFIX_LOOKUP[prefix.lower()]
@@ -337,7 +337,7 @@ class QueryHandler:
         vod = {
             'id': f'normalize.disease:{quote(query)}',
             'type': 'DiseaseDescriptor',
-            'disease': record['concept_id'],
+            'disease_id': record['concept_id'],
             'label': record['label'],
             'extensions': [],
         }

--- a/disease/schemas.py
+++ b/disease/schemas.py
@@ -338,7 +338,7 @@ class NormalizationService(BaseModel):
                 "disease_descriptor": {
                     "id": "normalize:childhood%20leukemia",
                     "type": "DiseaseDescriptor",
-                    "disease": "ncit:C4989",
+                    "disease_id": "ncit:C4989",
                     "label": "Childhood Leukemia",
                     "xrefs": [
                         "mondo:0004355",

--- a/disease/version.py
+++ b/disease/version.py
@@ -1,2 +1,2 @@
 """Disease normalizer version"""
-__version__ = "0.2.17"
+__version__ = "0.2.18"

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -31,7 +31,7 @@ def neuroblastoma():
     return ValueObjectDescriptor(**{
         "id": "normalize.disease:Neuroblastoma",
         "type": "DiseaseDescriptor",
-        "disease": "ncit:C3270",
+        "disease_id": "ncit:C3270",
         "label": "Neuroblastoma",
         "xrefs": [
             "mondo:0005072",
@@ -79,7 +79,7 @@ def skin_myo():
     return ValueObjectDescriptor(**{
         "id": "normalize.disease:Skin Myoepithelioma",
         "type": "DiseaseDescriptor",
-        "disease": "ncit:C167370",
+        "disease_id": "ncit:C167370",
         "label": "Skin Myoepithelioma",
         "alternate_labels": ["Cutaneous Myoepithelioma"],
     })
@@ -93,7 +93,7 @@ def mafd2():
     return ValueObjectDescriptor(**{
         "id": "normalize.disease:MAFD2",
         "type": "DiseaseDescriptor",
-        "disease": "mondo:0010648",
+        "disease_id": "mondo:0010648",
         "label": "major affective disorder 2",
         "alternate_labels": [
             "MAFD2",
@@ -126,7 +126,7 @@ def compare_vod(actual, fixture):
     actual = actual.disease_descriptor
     assert actual.id == fixture.id
     assert actual.type == fixture.type
-    assert actual.disease == fixture.disease
+    assert actual.disease_id == fixture.disease_id
     assert actual.label == fixture.label
 
     assert (actual.xrefs is not None) == (fixture.xrefs is not None)


### PR DESCRIPTION
Close #100 

Accidentally snuck in [this](https://github.com/cancervariants/disease-normalization/pull/84) PR. Eventually we will move to metaschema-update change where `DiseaseDescriptor.disease_id` --> `DiseaseDescriptor.disease`. 