### PR TITLE
feat: add get_all_records DB method

### DIFF
--- a/disease/database/database.py
+++ b/disease/database/database.py
@@ -4,11 +4,11 @@ import sys
 from enum import Enum
 from os import environ
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, Generator, List, Optional, Set, Union
 
 import click
 
-from disease.schemas import RefType, SourceMeta, SourceName
+from disease.schemas import RecordType, RefType, SourceMeta, SourceName
 
 
 class DatabaseException(Exception):  # noqa: N818
@@ -140,6 +140,25 @@ class AbstractDatabase(abc.ABC):
 
         :param source: optionally, just get all IDs for a specific source
         :return: Set of concept IDs as strings.
+        """
+
+    @abc.abstractmethod
+    def get_all_records(self, record_type: RecordType) -> Generator[Dict, None, None]:
+        """Retrieve all source or normalized records. Either return all source records,
+        or all records that qualify as "normalized" (i.e., merged groups + source
+        records that are otherwise ungrouped).
+        For example,
+
+        .. code-block::pycon
+
+           >>> from disease.database import create_db
+           >>> from disease.schemas import RecordType
+           >>> db = create_db()
+           >>> for record in db.get_all_records(RecordType.MERGER):
+           >>>     pass  # do something
+
+        :param record_type: type of result to return
+        :return: Generator that lazily provides records as they are retrieved
         """
 
     @abc.abstractmethod

--- a/disease/database/postgresql.py
+++ b/disease/database/postgresql.py
@@ -293,7 +293,7 @@ class PostgresDatabase(AbstractDatabase):
         """Restructure row from disease_concepts table as source record result object.
 
         :param source_row: result tuple from psycopg
-        :return: reformatted dictionary keying gene properties to row values
+        :return: reformatted dictionary keying disease properties to row values
         """
         disease_record = {
             "concept_id": source_row[0],

--- a/disease/database/postgresql.py
+++ b/disease/database/postgresql.py
@@ -6,7 +6,7 @@ import tarfile
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union
 
 import psycopg
 import requests
@@ -18,7 +18,7 @@ from psycopg.errors import (
 )
 
 from disease.database import AbstractDatabase, DatabaseException, DatabaseWriteException
-from disease.schemas import RefType, SourceMeta, SourceName
+from disease.schemas import RecordType, RefType, SourceMeta, SourceName
 
 logger = logging.getLogger()
 
@@ -289,6 +289,25 @@ class PostgresDatabase(AbstractDatabase):
 
     _record_query = b"SELECT * FROM record_lookup_view WHERE lower(concept_id) = %s;"
 
+    def _format_source_record(self, source_row: Tuple) -> Dict:
+        """Restructure row from disease_concepts table as source record result object.
+
+        :param source_row: result tuple from psycopg
+        :return: reformatted dictionary keying gene properties to row values
+        """
+        disease_record = {
+            "concept_id": source_row[0],
+            "label": source_row[1],
+            "aliases": source_row[2],
+            "associated_with": source_row[3],
+            "xrefs": source_row[4],
+            "src_name": source_row[5],
+            "merge_ref": source_row[6],
+            "pediatric_disease": source_row[7],
+            "item_type": RecordType.IDENTITY.value,
+        }
+        return {k: v for k, v in disease_record.items() if v}
+
     def _get_record(self, concept_id: str, case_sensitive: bool) -> Optional[Dict]:
         """Retrieve non-merged record. The query is pretty different, so this method
         is broken out for PostgreSQL.
@@ -306,20 +325,26 @@ class PostgresDatabase(AbstractDatabase):
         if not result:
             return None
 
-        disease_record = {
-            "concept_id": result[0],
-            "label": result[1],
-            "aliases": result[2],
-            "associated_with": result[3],
-            "xrefs": result[4],
-            "src_name": result[5],
-            "merge_ref": result[6],
-            "pediatric_disease": result[7],
-            "item_type": "identity",
-        }
-        return {k: v for k, v in disease_record.items() if v}
+        return self._format_source_record(result)
 
     _merged_record_query = b"SELECT * FROM disease_merged WHERE lower(concept_id) = %s;"
+
+    def _format_merged_record(self, merged_row: Tuple) -> Dict:
+        """Restructure row from disease_merged table as normalized result object.
+
+        :param merged_row: result tuple from psycopg
+        :return: reformatted dictionary keying normalized gene properties to row values
+        """
+        merged_record = {
+            "concept_id": merged_row[0],
+            "label": merged_row[1],
+            "aliases": merged_row[2],
+            "associated_with": merged_row[3],
+            "xrefs": merged_row[4],
+            "pediatric_disease": merged_row[5],
+            "item_type": RecordType.MERGER.value,
+        }
+        return {k: v for k, v in merged_record.items() if v}
 
     def _get_merged_record(
         self, concept_id: str, case_sensitive: bool
@@ -338,16 +363,7 @@ class PostgresDatabase(AbstractDatabase):
         if not result:
             return None
 
-        merged_record = {
-            "concept_id": result[0],
-            "label": result[1],
-            "aliases": result[2],
-            "associated_with": result[3],
-            "xrefs": result[4],
-            "pediatric_disease": result[5],
-            "item_type": "merger",
-        }
-        return {k: v for k, v in merged_record.items() if v}
+        return self._format_merged_record(result)
 
     def get_record_by_id(
         self, concept_id: str, case_sensitive: bool = True, merge: bool = False
@@ -416,6 +432,61 @@ class PostgresDatabase(AbstractDatabase):
                 cur.execute(ids_query, (source,))
             ids_tuple = cur.fetchall()
         return {i[0] for i in ids_tuple}
+
+    _get_all_normalized_records_query = b"SELECT * FROM disease_merged;"
+    _get_all_unmerged_source_records_query = (
+        b"SELECT * FROM record_lookup_view WHERE merge_ref IS NULL;"  # noqa: E501
+    )
+    _get_all_source_records_query = b"SELECT * FROM record_lookup_view;"
+
+    def get_all_records(self, record_type: RecordType) -> Generator[Dict, None, None]:
+        """Retrieve all source or normalized records. Either return all source records,
+        or all records that qualify as "normalized" (i.e., merged groups + source
+        records that are otherwise ungrouped).
+
+        For example,
+
+        .. code-block::pycon
+
+           >>> from disease.database import create_db
+           >>> from disease.schemas import RecordType
+           >>> db = create_db()
+           >>> for record in db.get_all_records(RecordType.MERGER):
+           >>>     pass  # do something
+
+        Unlike DynamoDB, merged records are stored in a separate table from source
+        records. As a result, when fetching all normalized records, merged records are
+        return first, and iteration continues with all source records that don't
+        belong to a normalized concept group.
+
+        :param record_type: type of result to return
+        :return: Generator that lazily provides records as they are retrieved
+        """
+        batch_size = 500
+
+        if record_type == RecordType.MERGER:
+            with self.conn.cursor() as cur:
+                results = cur.execute(self._get_all_normalized_records_query)
+                fetched = results.fetchmany(batch_size)
+                while fetched:
+                    for row in fetched:
+                        yield self._format_merged_record(row)
+                    fetched = results.fetchmany(batch_size)
+            with self.conn.cursor() as cur:
+                results = cur.execute(self._get_all_unmerged_source_records_query)
+                fetched = results.fetchmany(batch_size)
+                while fetched:
+                    for result in fetched:
+                        yield self._format_source_record(result)
+                    fetched = results.fetchmany(batch_size)
+        else:
+            with self.conn.cursor() as cur:
+                results = cur.execute(self._get_all_source_records_query)
+                fetched = results.fetchmany(batch_size)
+                while fetched:
+                    for result in fetched:
+                        yield self._format_source_record(result)
+                    fetched = results.fetchmany(batch_size)
 
     _add_source_metadata_query = b"""
     INSERT INTO disease_sources(

--- a/disease/database/postgresql.py
+++ b/disease/database/postgresql.py
@@ -333,7 +333,7 @@ class PostgresDatabase(AbstractDatabase):
         """Restructure row from disease_merged table as normalized result object.
 
         :param merged_row: result tuple from psycopg
-        :return: reformatted dictionary keying normalized gene properties to row values
+        :return: reformatted dictionary keying normalized disease properties to row values
         """
         merged_record = {
             "concept_id": merged_row[0],

--- a/disease/etl/base.py
+++ b/disease/etl/base.py
@@ -58,11 +58,6 @@ class Base(ABC):
         """
         return bioversions.get_version(self._src_name)
 
-    @abstractmethod
-    def _download_data(self) -> None:
-        """Download source data."""
-        raise NotImplementedError
-
     def _zip_handler(self, dl_path: Path, outfile_path: Path) -> None:
         """Provide simple callback function to extract the largest file within a given
         zipfile and save it within the appropriate data directory.

--- a/disease/schemas.py
+++ b/disease/schemas.py
@@ -133,6 +133,13 @@ class DataLicenseAttributes(BaseModel):
     attribution: StrictBool
 
 
+class RecordType(str, Enum):
+    """Record item types."""
+
+    IDENTITY = "identity"
+    MERGER = "merger"
+
+
 class RefType(str, Enum):
     """Reference item types."""
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -3,6 +3,11 @@ import os
 
 import pytest
 
+from disease.schemas import RecordType
+
+IS_DDB = not os.environ.get("DISEASE_NORM_DB_URL", "").lower().startswith("postgres")
+IS_TEST_ENV = os.environ.get("DISEASE_TEST", "").lower() == "true"
+
 
 def test_tables_created(database):
     """Check that required tables are created."""
@@ -20,9 +25,6 @@ def test_tables_created(database):
     else:
         assert database.disease_concepts_table in existing_tables
         assert database.disease_metadata_table in existing_tables
-
-
-IS_DDB = not os.environ.get("DISEASE_NORM_DB_URL", "").lower().startswith("postgres")
 
 
 @pytest.mark.skipif(not IS_DDB, reason="only applies to DynamoDB in test env")
@@ -59,3 +61,22 @@ def test_item_type(database):
     item = database.diseases.query(KeyConditionExpression=filter_exp)["Items"][0]
     assert "item_type" in item
     assert item["item_type"] == "merger"
+
+
+@pytest.mark.skipif(not IS_TEST_ENV, reason="not in test environment")
+def database(db_fixture):
+    """Perform basic test of get_all_records method.
+
+    It's probably overkill (and unmaintainable) to do exact checks against every
+    record, but fairly easy to check against expected counts and ensure that nothing
+    is getting sent twice.
+    """
+    source_records = list(db_fixture.get_all_records(RecordType.IDENTITY))
+    assert len(source_records) == 1463
+    source_ids = {r["concept_id"] for r in source_records}
+    assert len(source_ids) == 1463
+
+    normalized_records = list(db_fixture.get_all_records(RecordType.MERGER))
+    assert len(normalized_records) == 1391
+    normalized_ids = {r["concept_id"] for r in normalized_records}
+    assert len(normalized_ids) == 1391


### PR DESCRIPTION
Utility method -- chiefly for analysis, but could be helpful in other cases -- to lazily fetch all records from the database. Already implemented in the Gene Normalizer.