### PR TITLE
fix: catch ETL module import errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ export DISEASE_NORM_DB_URL="postgresql://postgres@localhost:5432/disease_normali
 
 Use the `disease_norm_update` command in a shell to update the database.
 
+If you encounter an error message like the following, refer to the installation instructions above:
+
+```shell
+"Encountered ModuleNotFoundError attempting to import Mondo. Are ETL dependencies installed?"
+```
+
 #### Update source(s)
 
 The Disease Normalizer currently uses data from the following sources:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ Source = "https://github.com/cancervariants/disease-normalization"
 "Bug Tracker" = "https://github.com/cancervariants/disease-normalization/issues"
 
 [project.scripts]
-disease_norm_update = "disease.cli:update_normalizer_db"
+disease_norm_update = "disease.cli:update_db"
 disease_norm_update_remote = "disease.cli:update_from_remote"
 disease_norm_dump = "disease.cli:dump_database"
 disease_norm_check_db = "disease.cli:check_db"

--- a/src/disease/cli.py
+++ b/src/disease/cli.py
@@ -16,12 +16,6 @@ from disease.database.database import (
 )
 from disease.schemas import SourceName
 
-# Use to lookup class object from source name. Should be one key-value pair
-# for every functioning ETL class.
-SOURCES_CLASS_LOOKUP = {
-    s.value.lower(): eval(s.value) for s in SourceName.__members__.values()
-}
-
 
 @click.command()
 @click.option("--db_url", help="URL endpoint for the application database.")


### PR DESCRIPTION
This reflects changes made in a PR on gene from a while back. Instead of raising an exception when ETL dependencies aren't installed, the console displays this message instead:

```shell
[ etl-import-fix ⚙ venv] ~/code/disease-normalization % disease_norm_update --sources=mondo                                                                                                                                                                     
***Using Disease Database Endpoint: http://localhost:8001***    
                                                                
Deleting Mondo...                                                                                                                                                                                                                                                
Deleted Mondo in 0.04582 seconds.        
                                                                
Loading Mondo...                                                                                                                
Encountered ModuleNotFoundError attempting to import bioversions. Are ETL dependencies installed?
```