### PR TITLE
chore!: rename optional dependency

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -39,11 +39,11 @@ jobs:
 
     - name: Install DynamoDB dependencies
       if: ${{ env.DISEASE_NORM_DB_URL == 'http://localhost:8002' }}
-      run: python3 -m pip install ".[etl,tests]"
+      run: python3 -m pip install ".[etl,test]"
 
     - name: Install PG dependencies
       if: ${{ env.DISEASE_NORM_DB_URL != 'http://localhost:8002' }}
-      run: python3 -m pip install ".[pg,etl,tests]"
+      run: python3 -m pip install ".[pg,etl,test]"
 
     - name: Run tests
       run: python3 -m pytest tests/

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -18,7 +18,7 @@ Then initialize a virtual environment: ::
 
     python3 -m virtualenv venv
     source venv/bin/activate
-    python3 -m pip install -e '.[dev,tests,docs]'
+    python3 -m pip install -e '.[dev,test,docs]'
 
 We use `pre-commit <https://pre-commit.com/#usage>`_ to run conformance tests before commits. This provides checks for:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 pg = ["psycopg[binary]", "requests"]
 etl = ["owlready2==0.40", "rdflib", "wags-tails>=0.1.2", "fastobo", "tqdm"]
-tests = ["pytest>=6.0", "pytest-cov", "httpx"]
+test = ["pytest>=6.0", "pytest-cov", "httpx"]
 dev = ["pre-commit>=3.7.1", "ruff==0.5.0", "lxml", "xmlformatter"]
 docs = [
     "sphinx==6.1.3",


### PR DESCRIPTION
* `tests` -> `test`

To be consistent with our other tools