### PR TITLE
fix!: use correct representation of Coding object in mappings

### DIFF
--- a/src/disease/query.py
+++ b/src/disease/query.py
@@ -304,7 +304,7 @@ class QueryHandler:
 
         sources = []
         for m in disease.mappings or []:
-            ns = m.coding.id.split(":")[0]
+            ns = m.coding.id.split(":")[0].lower()
             if ns in PREFIX_LOOKUP:
                 sources.append(PREFIX_LOOKUP[ns])
 
@@ -348,7 +348,12 @@ class QueryHandler:
                     err_msg = f"Namespace prefix not supported: {source}"
                     raise ValueError(err_msg) from e
 
-            system = NAMESPACE_TO_SYSTEM_URI.get(source, source)
+            if source == NamespacePrefix.MONDO:
+                source_code = concept_id.upper()
+            elif source == NamespacePrefix.DOID:
+                source_code = concept_id
+
+            system = NAMESPACE_TO_SYSTEM_URI[source]
 
             return ConceptMapping(
                 coding=Coding(id=concept_id, code=code(source_code), system=system),

--- a/src/disease/query.py
+++ b/src/disease/query.py
@@ -31,16 +31,17 @@ from disease.schemas import (
 _logger = logging.getLogger(__name__)
 
 
-def create_concept_mapping(
+def get_concept_mapping(
     concept_id: str, relation: Relation = Relation.RELATED_MATCH
 ) -> ConceptMapping:
-    """Create concept mapping for identifier
+    """Get concept mapping for CURIE identifier
 
     ``system`` will use system prefix URL, OBO Foundry persistent URL (PURL), or
     source homepage, in that order of preference.
 
     :param concept_id: Concept identifier represented as a curie
     :param relation: SKOS mapping relationship, default is relatedMatch
+    :raises ValueError: If source of concept ID is not a valid ``NamespacePrefix``
     :return: Concept mapping for identifier
     """
     source, source_code = concept_id.split(":")
@@ -370,10 +371,10 @@ class QueryHandler:
 
         # mappings
         mappings = [
-            create_concept_mapping(record["concept_id"], relation=Relation.EXACT_MATCH)
+            get_concept_mapping(record["concept_id"], relation=Relation.EXACT_MATCH)
         ]
         source_ids = record.get("xrefs", []) + record.get("associated_with", [])
-        mappings.extend(create_concept_mapping(source_id) for source_id in source_ids)
+        mappings.extend(get_concept_mapping(source_id) for source_id in source_ids)
         if mappings:
             disease_obj.mappings = mappings
 

--- a/src/disease/query.py
+++ b/src/disease/query.py
@@ -60,10 +60,12 @@ def get_concept_mapping(
     elif source == NamespacePrefix.DOID:
         source_code = concept_id
 
-    system = NAMESPACE_TO_SYSTEM_URI[source]
-
     return ConceptMapping(
-        coding=Coding(id=concept_id, code=code(source_code), system=system),
+        coding=Coding(
+            id=concept_id,
+            code=code(source_code),
+            system=NAMESPACE_TO_SYSTEM_URI[source],
+        ),
         relation=relation,
     )
 

--- a/src/disease/schemas.py
+++ b/src/disease/schemas.py
@@ -79,7 +79,7 @@ NAMESPACE_TO_SYSTEM_URI: MappingProxyType[NamespacePrefix, str] = MappingProxyTy
         NamespacePrefix.MONDO: "http://purl.obolibrary.org/obo/mondo.owl",
         NamespacePrefix.DO: "https://disease-ontology.org/?id=",
         NamespacePrefix.DOID: "https://disease-ontology.org/?id=",
-        NamespacePrefix.OMIM: "https://omim.org/entry/",
+        NamespacePrefix.OMIM: "https://omim.org/",
         NamespacePrefix.ONCOTREE: "https://oncotree.mskcc.org/?version=oncotree_latest_stable&field=CODE&search=",
         NamespacePrefix.EFO: "http://www.ebi.ac.uk/efo/EFO_",
         NamespacePrefix.GARD: "https://rarediseases.info.nih.gov",

--- a/src/disease/schemas.py
+++ b/src/disease/schemas.py
@@ -55,71 +55,44 @@ class NamespacePrefix(Enum):
     OMIM = "MIM"
     ONCOTREE = "oncotree"
     # external sources
-    COHD = "cohd"
-    DECIPHER = "decipher"
     EFO = "efo"
     GARD = "gard"
-    HP = "HP"
-    HPO = HP
-    ICD9 = "icd9"
     ICD9CM = "icd9.cm"
     ICD10 = "icd10"
     ICD10WHO = ICD10
     ICD10CM = "icd10.cm"
-    ICD11 = "icd11"
     ICDO = "icdo"
-    IDO = "ido"
     IMDRF = "imdrf"
     KEGG = "kegg.disease"
     MEDDRA = "meddra"
     MEDGEN = "medgen"
     MESH = "mesh"
-    MF = "mf"
-    MP = "MP"
-    MPATH = "mpath"
-    NIFSTD = "nifstd"
-    OBI = "obi"
-    OGMS = "ogms"
     ORPHANET = "orphanet"
-    PATO = "pato"
-    SCDO = "scdo"
     UMLS = "umls"
-    WIKIPEDIA = "wikipedia.en"
-    WIKIDATA = "wikidata"
 
 
-# Source to URI. Will use OBO Foundry persistent URL (PURL) or source homepage
+# Source to URI. Will use  system URI prefix, OBO Foundry persistent URL (PURL), or source homepage
 NAMESPACE_TO_SYSTEM_URI: dict[NamespacePrefix, str] = {
-    NamespacePrefix.NCIT: "http://purl.obolibrary.org/obo/ncit.owl",
+    NamespacePrefix.NCIT: "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=",
     NamespacePrefix.MONDO: "http://purl.obolibrary.org/obo/mondo.owl",
-    NamespacePrefix.DO: "http://purl.obolibrary.org/obo/doid.owl",
-    NamespacePrefix.DOID: "http://purl.obolibrary.org/obo/doid.owl",
-    NamespacePrefix.OMIM: "https://www.omim.org",
-    NamespacePrefix.ONCOTREE: "https://oncotree.mskcc.org",
-    NamespacePrefix.COHD: "https://cohd.io",
-    NamespacePrefix.DECIPHER: "https://www.deciphergenomics.org",
-    NamespacePrefix.EFO: "https://www.ebi.ac.uk/efo/",
+    NamespacePrefix.DO: "https://disease-ontology.org/?id=",
+    NamespacePrefix.DOID: "https://disease-ontology.org/?id=",
+    NamespacePrefix.OMIM: "https://omim.org/entry/",
+    NamespacePrefix.ONCOTREE: "https://oncotree.mskcc.org/?version=oncotree_latest_stable&field=CODE&search=",
+    NamespacePrefix.EFO: "http://www.ebi.ac.uk/efo/EFO_",
     NamespacePrefix.GARD: "https://rarediseases.info.nih.gov",
-    NamespacePrefix.HP: "http://purl.obolibrary.org/obo/hp.owl",
-    NamespacePrefix.HPO: "http://purl.obolibrary.org/obo/hp.owl",
-    NamespacePrefix.ICD11: "https://icd.who.int/en/",
+    NamespacePrefix.ICD9CM: "https://archive.cdc.gov/www_cdc_gov/nchs/icd/icd9cm.htm",
+    NamespacePrefix.ICD10: "https://icd.who.int/browse10/2016/en#/",
+    NamespacePrefix.ICD10CM: "https://www.cdc.gov/nchs/icd/icd-10-cm/index.html",
+    NamespacePrefix.ICD10WHO: "https://icd.who.int/browse10/2016/en#/",
     NamespacePrefix.ICDO: "https://www.who.int/standards/classifications/other-classifications/international-classification-of-diseases-for-oncology/",
+    NamespacePrefix.IMDRF: "https://www.imdrf.org/",
     NamespacePrefix.KEGG: "https://www.genome.jp/kegg/disease/",
-    NamespacePrefix.MEDDRA: "https://www.meddra.org",
+    NamespacePrefix.MEDDRA: "https://bioportal.bioontology.org/ontologies/MEDDRA?p=classes&conceptid=",
     NamespacePrefix.MEDGEN: "https://www.ncbi.nlm.nih.gov/medgen/",
-    NamespacePrefix.MESH: "https://id.nlm.nih.gov/mesh/",
-    NamespacePrefix.MP: "http://purl.obolibrary.org/obo/mp.owl",
-    NamespacePrefix.OBI: "http://purl.obolibrary.org/obo/obi.owl",
+    NamespacePrefix.MESH: "https://meshb.nlm.nih.gov/record/ui?ui=",
     NamespacePrefix.ORPHANET: "https://www.orpha.net",
-    NamespacePrefix.PATO: "http://purl.obolibrary.org/obo/pato.owl",
     NamespacePrefix.UMLS: "https://www.nlm.nih.gov/research/umls/index.html",
-    NamespacePrefix.WIKIPEDIA: "https://en.wikipedia.org",
-    NamespacePrefix.WIKIDATA: "https://www.wikidata.org",
-}
-
-# URI to source
-SYSTEM_URI_TO_NAMESPACE = {
-    system_uri: ns.value for ns, system_uri in NAMESPACE_TO_SYSTEM_URI.items()
 }
 
 
@@ -329,7 +302,7 @@ class NormalizationService(BaseModel):
                         {
                             "coding": {
                                 "code": "DOID:7757",
-                                "system": "http://purl.obolibrary.org/obo/doid.owl",
+                                "system": "https://disease-ontology.org/?id=",
                             },
                             "relation": "relatedMatch",
                         },

--- a/src/disease/schemas.py
+++ b/src/disease/schemas.py
@@ -79,7 +79,7 @@ NAMESPACE_TO_SYSTEM_URI: MappingProxyType[NamespacePrefix, str] = MappingProxyTy
         NamespacePrefix.MONDO: "https://monarchinitiative.org/",
         NamespacePrefix.DO: "https://disease-ontology.org/?id=",
         NamespacePrefix.DOID: "https://disease-ontology.org/?id=",
-        NamespacePrefix.OMIM: "https://omim.org/",
+        NamespacePrefix.OMIM: "https://omim.org/MIM:",
         NamespacePrefix.ONCOTREE: "https://oncotree.mskcc.org/?version=oncotree_latest_stable&field=CODE&search=",
         NamespacePrefix.EFO: "http://www.ebi.ac.uk/efo/EFO_",
         NamespacePrefix.GARD: "https://rarediseases.info.nih.gov",

--- a/src/disease/schemas.py
+++ b/src/disease/schemas.py
@@ -2,6 +2,7 @@
 
 import datetime
 from enum import Enum, IntEnum
+from types import MappingProxyType
 from typing import Literal
 
 from ga4gh.core.models import MappableConcept
@@ -72,28 +73,30 @@ class NamespacePrefix(Enum):
 
 
 # Source to URI. Will use  system URI prefix, OBO Foundry persistent URL (PURL), or source homepage
-NAMESPACE_TO_SYSTEM_URI: dict[NamespacePrefix, str] = {
-    NamespacePrefix.NCIT: "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=",
-    NamespacePrefix.MONDO: "http://purl.obolibrary.org/obo/mondo.owl",
-    NamespacePrefix.DO: "https://disease-ontology.org/?id=",
-    NamespacePrefix.DOID: "https://disease-ontology.org/?id=",
-    NamespacePrefix.OMIM: "https://omim.org/entry/",
-    NamespacePrefix.ONCOTREE: "https://oncotree.mskcc.org/?version=oncotree_latest_stable&field=CODE&search=",
-    NamespacePrefix.EFO: "http://www.ebi.ac.uk/efo/EFO_",
-    NamespacePrefix.GARD: "https://rarediseases.info.nih.gov",
-    NamespacePrefix.ICD9CM: "https://archive.cdc.gov/www_cdc_gov/nchs/icd/icd9cm.htm",
-    NamespacePrefix.ICD10: "https://icd.who.int/browse10/2016/en#/",
-    NamespacePrefix.ICD10CM: "https://www.cdc.gov/nchs/icd/icd-10-cm/index.html",
-    NamespacePrefix.ICD10WHO: "https://icd.who.int/browse10/2016/en#/",
-    NamespacePrefix.ICDO: "https://www.who.int/standards/classifications/other-classifications/international-classification-of-diseases-for-oncology/",
-    NamespacePrefix.IMDRF: "https://www.imdrf.org/",
-    NamespacePrefix.KEGG: "https://www.genome.jp/kegg/disease/",
-    NamespacePrefix.MEDDRA: "https://bioportal.bioontology.org/ontologies/MEDDRA?p=classes&conceptid=",
-    NamespacePrefix.MEDGEN: "https://www.ncbi.nlm.nih.gov/medgen/",
-    NamespacePrefix.MESH: "https://meshb.nlm.nih.gov/record/ui?ui=",
-    NamespacePrefix.ORPHANET: "https://www.orpha.net",
-    NamespacePrefix.UMLS: "https://www.nlm.nih.gov/research/umls/index.html",
-}
+NAMESPACE_TO_SYSTEM_URI: MappingProxyType[NamespacePrefix, str] = MappingProxyType(
+    {
+        NamespacePrefix.NCIT: "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=",
+        NamespacePrefix.MONDO: "http://purl.obolibrary.org/obo/mondo.owl",
+        NamespacePrefix.DO: "https://disease-ontology.org/?id=",
+        NamespacePrefix.DOID: "https://disease-ontology.org/?id=",
+        NamespacePrefix.OMIM: "https://omim.org/entry/",
+        NamespacePrefix.ONCOTREE: "https://oncotree.mskcc.org/?version=oncotree_latest_stable&field=CODE&search=",
+        NamespacePrefix.EFO: "http://www.ebi.ac.uk/efo/EFO_",
+        NamespacePrefix.GARD: "https://rarediseases.info.nih.gov",
+        NamespacePrefix.ICD9CM: "https://archive.cdc.gov/www_cdc_gov/nchs/icd/icd9cm.htm",
+        NamespacePrefix.ICD10: "https://icd.who.int/browse10/2016/en#/",
+        NamespacePrefix.ICD10CM: "https://www.cdc.gov/nchs/icd/icd-10-cm/index.html",
+        NamespacePrefix.ICD10WHO: "https://icd.who.int/browse10/2016/en#/",
+        NamespacePrefix.ICDO: "https://www.who.int/standards/classifications/other-classifications/international-classification-of-diseases-for-oncology/",
+        NamespacePrefix.IMDRF: "https://www.imdrf.org/",
+        NamespacePrefix.KEGG: "https://www.genome.jp/kegg/disease/",
+        NamespacePrefix.MEDDRA: "https://bioportal.bioontology.org/ontologies/MEDDRA?p=classes&conceptid=",
+        NamespacePrefix.MEDGEN: "https://www.ncbi.nlm.nih.gov/medgen/",
+        NamespacePrefix.MESH: "https://meshb.nlm.nih.gov/record/ui?ui=",
+        NamespacePrefix.ORPHANET: "https://www.orpha.net",
+        NamespacePrefix.UMLS: "https://www.nlm.nih.gov/research/umls/index.html",
+    }
+)
 
 
 class SourcePriority(IntEnum):

--- a/src/disease/schemas.py
+++ b/src/disease/schemas.py
@@ -76,7 +76,7 @@ class NamespacePrefix(Enum):
 NAMESPACE_TO_SYSTEM_URI: MappingProxyType[NamespacePrefix, str] = MappingProxyType(
     {
         NamespacePrefix.NCIT: "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=",
-        NamespacePrefix.MONDO: "http://purl.obolibrary.org/obo/mondo.owl",
+        NamespacePrefix.MONDO: "https://monarchinitiative.org/",
         NamespacePrefix.DO: "https://disease-ontology.org/?id=",
         NamespacePrefix.DOID: "https://disease-ontology.org/?id=",
         NamespacePrefix.OMIM: "https://omim.org/",
@@ -300,7 +300,7 @@ class NormalizationService(BaseModel):
                             "coding": {
                                 "id": "mondo:0004355",
                                 "code": "MONDO:0004355",
-                                "system": "http://purl.obolibrary.org/obo/mondo.owl",
+                                "system": "https://monarchinitiative.org/",
                             },
                             "relation": "relatedMatch",
                         },

--- a/src/disease/schemas.py
+++ b/src/disease/schemas.py
@@ -287,20 +287,23 @@ class NormalizationService(BaseModel):
                     "mappings": [
                         {
                             "coding": {
-                                "code": "ncit:C4989",
+                                "id": "ncit:C4989",
+                                "code": "C4989",
                                 "system": "https://www.ebi.ac.uk/ols4/ontologies/ncit/classes?short_form=NCIT_",
                             },
                             "relation": "exactMatch",
                         },
                         {
                             "coding": {
-                                "code": "mondo:0004355",
+                                "id": "mondo:0004355",
+                                "code": "MONDO:0004355",
                                 "system": "http://purl.obolibrary.org/obo/mondo.owl",
                             },
                             "relation": "relatedMatch",
                         },
                         {
                             "coding": {
+                                "id": "DOID:7757",
                                 "code": "DOID:7757",
                                 "system": "https://disease-ontology.org/?id=",
                             },
@@ -308,7 +311,8 @@ class NormalizationService(BaseModel):
                         },
                         {
                             "coding": {
-                                "code": "umls:C1332977",
+                                "id": "umls:C1332977",
+                                "code": "C1332977",
                                 "system": "https://www.nlm.nih.gov/research/umls/index.html",
                             },
                             "relation": "relatedMatch",

--- a/src/disease/schemas.py
+++ b/src/disease/schemas.py
@@ -289,7 +289,7 @@ class NormalizationService(BaseModel):
                             "coding": {
                                 "id": "ncit:C4989",
                                 "code": "C4989",
-                                "system": "https://www.ebi.ac.uk/ols4/ontologies/ncit/classes?short_form=NCIT_",
+                                "system": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=",
                             },
                             "relation": "exactMatch",
                         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ def pytest_collection_modifyitems(items):
     When creating new test modules, be sure to add them here.
     """
     module_order = [
+        "test_schemas",
         "test_mondo",
         "test_do",
         "test_ncit",

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -34,9 +34,9 @@ def neuroblastoma():
             },
             {
                 "coding": {
-                    "id": "mondo:0005072",
+                    "id": "MONDO_0005072",
                     "code": "MONDO:0005072",
-                    "system": "https://monarchinitiative.org/",
+                    "system": "https://purl.obolibrary.org/obo/",
                 },
                 "relation": "relatedMatch",
             },
@@ -178,9 +178,9 @@ def mafd2():
         mappings=[
             {
                 "coding": {
-                    "id": "mondo:0010648",
+                    "id": "MONDO_0010648",
                     "code": "MONDO:0010648",
-                    "system": "https://monarchinitiative.org/",
+                    "system": "https://purl.obolibrary.org/obo/",
                 },
                 "relation": "exactMatch",
             },

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -188,7 +188,7 @@ def mafd2():
                 "coding": {
                     "id": "MIM:309200",
                     "code": "309200",
-                    "system": "https://omim.org/",
+                    "system": "https://omim.org/MIM:",
                 },
                 "relation": "relatedMatch",
             },

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -27,7 +27,7 @@ def neuroblastoma():
             {
                 "coding": {
                     "code": "ncit:C3270",
-                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
+                    "system": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=",
                 },
                 "relation": "exactMatch",
             },
@@ -41,14 +41,14 @@ def neuroblastoma():
             {
                 "coding": {
                     "code": "oncotree:NBL",
-                    "system": "https://oncotree.mskcc.org",
+                    "system": "https://oncotree.mskcc.org/?version=oncotree_latest_stable&field=CODE&search=",
                 },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
                     "code": "DOID:769",
-                    "system": "http://purl.obolibrary.org/obo/doid.owl",
+                    "system": "https://disease-ontology.org/?id=",
                 },
                 "relation": "relatedMatch",
             },
@@ -69,7 +69,7 @@ def neuroblastoma():
             {
                 "coding": {
                     "code": "efo:0000621",
-                    "system": "https://www.ebi.ac.uk/efo/",
+                    "system": "http://www.ebi.ac.uk/efo/EFO_",
                 },
                 "relation": "relatedMatch",
             },
@@ -83,7 +83,7 @@ def neuroblastoma():
             {
                 "coding": {
                     "code": "mesh:D009447",
-                    "system": "https://id.nlm.nih.gov/mesh/",
+                    "system": "https://meshb.nlm.nih.gov/record/ui?ui=",
                 },
                 "relation": "relatedMatch",
             },
@@ -143,7 +143,7 @@ def skin_myo():
             {
                 "coding": {
                     "code": "ncit:C167370",
-                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
+                    "system": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=",
                 },
                 "relation": "exactMatch",
             },
@@ -171,13 +171,13 @@ def mafd2():
                 "relation": "exactMatch",
             },
             {
-                "coding": {"code": "MIM:309200", "system": "https://www.omim.org"},
+                "coding": {"code": "MIM:309200", "system": "https://omim.org/entry/"},
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
                     "code": "mesh:C564108",
-                    "system": "https://id.nlm.nih.gov/mesh/",
+                    "system": "https://meshb.nlm.nih.gov/record/ui?ui=",
                 },
                 "relation": "relatedMatch",
             },

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -26,27 +26,31 @@ def neuroblastoma():
         mappings=[
             {
                 "coding": {
-                    "code": "ncit:C3270",
+                    "id": "ncit:C3270",
+                    "code": "C3270",
                     "system": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=",
                 },
                 "relation": "exactMatch",
             },
             {
                 "coding": {
-                    "code": "mondo:0005072",
+                    "id": "mondo:0005072",
+                    "code": "MONDO:0005072",
                     "system": "http://purl.obolibrary.org/obo/mondo.owl",
                 },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
-                    "code": "oncotree:NBL",
+                    "id": "oncotree:NBL",
+                    "code": "NBL",
                     "system": "https://oncotree.mskcc.org/?version=oncotree_latest_stable&field=CODE&search=",
                 },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
+                    "id": "DOID:769",
                     "code": "DOID:769",
                     "system": "https://disease-ontology.org/?id=",
                 },
@@ -54,56 +58,64 @@ def neuroblastoma():
             },
             {
                 "coding": {
-                    "code": "umls:C0027819",
+                    "id": "umls:C0027819",
+                    "code": "C0027819",
                     "system": "https://www.nlm.nih.gov/research/umls/index.html",
                 },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
-                    "code": "icdo:9500/3",
+                    "id": "icdo:9500/3",
+                    "code": "9500/3",
                     "system": "https://www.who.int/standards/classifications/other-classifications/international-classification-of-diseases-for-oncology/",
                 },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
-                    "code": "efo:0000621",
+                    "id": "efo:0000621",
+                    "code": "0000621",
                     "system": "http://www.ebi.ac.uk/efo/EFO_",
                 },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
-                    "code": "gard:7185",
+                    "id": "gard:7185",
+                    "code": "7185",
                     "system": "https://rarediseases.info.nih.gov",
                 },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
-                    "code": "mesh:D009447",
+                    "id": "mesh:D009447",
+                    "code": "D009447",
                     "system": "https://meshb.nlm.nih.gov/record/ui?ui=",
                 },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
-                    "code": "orphanet:635",
+                    "id": "orphanet:635",
+                    "code": "635",
                     "system": "https://www.orpha.net",
                 },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
-                    "code": "umls:C2751421",
+                    "id": "umls:C2751421",
+                    "code": "C2751421",
                     "system": "https://www.nlm.nih.gov/research/umls/index.html",
                 },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
-                    "code": "medgen:18012",
+                    "id": "medgen:18012",
+                    "code": "18012",
                     "system": "https://www.ncbi.nlm.nih.gov/medgen/",
                 },
                 "relation": "relatedMatch",
@@ -142,7 +154,8 @@ def skin_myo():
         mappings=[
             {
                 "coding": {
-                    "code": "ncit:C167370",
+                    "id": "ncit:C167370",
+                    "code": "C167370",
                     "system": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=",
                 },
                 "relation": "exactMatch",
@@ -165,32 +178,40 @@ def mafd2():
         mappings=[
             {
                 "coding": {
-                    "code": "mondo:0010648",
+                    "id": "mondo:0010648",
+                    "code": "MONDO:0010648",
                     "system": "http://purl.obolibrary.org/obo/mondo.owl",
                 },
                 "relation": "exactMatch",
             },
             {
-                "coding": {"code": "MIM:309200", "system": "https://omim.org/entry/"},
+                "coding": {
+                    "id": "MIM:309200",
+                    "code": "309200",
+                    "system": "https://omim.org/entry/",
+                },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
-                    "code": "mesh:C564108",
+                    "id": "mesh:C564108",
+                    "code": "C564108",
                     "system": "https://meshb.nlm.nih.gov/record/ui?ui=",
                 },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
-                    "code": "medgen:326975",
+                    "id": "medgen:326975",
+                    "code": "326975",
                     "system": "https://www.ncbi.nlm.nih.gov/medgen/",
                 },
                 "relation": "relatedMatch",
             },
             {
                 "coding": {
-                    "code": "umls:C1839839",
+                    "id": "umls:C1839839",
+                    "code": "C1839839",
                     "system": "https://www.nlm.nih.gov/research/umls/index.html",
                 },
                 "relation": "relatedMatch",

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -188,7 +188,7 @@ def mafd2():
                 "coding": {
                     "id": "MIM:309200",
                     "code": "309200",
-                    "system": "https://omim.org/entry/",
+                    "system": "https://omim.org/",
                 },
                 "relation": "relatedMatch",
             },

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -36,7 +36,7 @@ def neuroblastoma():
                 "coding": {
                     "id": "mondo:0005072",
                     "code": "MONDO:0005072",
-                    "system": "http://purl.obolibrary.org/obo/mondo.owl",
+                    "system": "https://monarchinitiative.org/",
                 },
                 "relation": "relatedMatch",
             },
@@ -180,7 +180,7 @@ def mafd2():
                 "coding": {
                     "id": "mondo:0010648",
                     "code": "MONDO:0010648",
-                    "system": "http://purl.obolibrary.org/obo/mondo.owl",
+                    "system": "https://monarchinitiative.org/",
                 },
                 "relation": "exactMatch",
             },

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,0 +1,10 @@
+"""Module to test the schemas module."""
+
+from disease.schemas import NAMESPACE_TO_SYSTEM_URI, NamespacePrefix
+
+
+def test_namespace_to_system_uri():
+    """Ensure that each NamespacePrefix is included in NAMESPACE_TO_SYSTEM_URI"""
+    for v in NamespacePrefix.__members__.values():
+        assert v in NAMESPACE_TO_SYSTEM_URI, v
+        assert NAMESPACE_TO_SYSTEM_URI[v].startswith("http"), v


### PR DESCRIPTION
close #220

* correct `Coding` representation
  * `system` MUST use `iriReference`, not a free-text label
  * `code` MUST use syntax defined by the `system`
  * `id` will use record `concept_id`
* `NAMESPACE_TO_SYSTEM_URI` is now a `MappingProxyType`
* Removes `SYSTEM_URI_TO_NAMESPACE` mapping (since it's no longer needed)
* Removes unused `NamespacePrefix` members (if needed, will be added back in #214):
  * `COHD`, `DECIPHER`, `HP`, `HPO`, `ICD9`, `ICD11`, `IDO`, `MF`, `MP`, `MPATH`, `NIFSTD`, `OBI`, `OGMS`, `PATO`, `SCDO`, `WIKIPEDIA`, `WIKIDATA`