### PR TITLE
feat: capture cancer subset in DO

### DIFF
--- a/src/disease/etl/do.py
+++ b/src/disease/etl/do.py
@@ -49,6 +49,10 @@ class DO(OWLBase):
         diseases = self._get_subclasses(
             disease_uri, owl.default_world.as_rdflib_graph()
         )
+        # use "disease of cellular proliferation" to capture related non- or pre-malignant
+        # disease terms
+        cancers_uri = "http://purl.obolibrary.org/obo/DOID_14566"
+        cancers = self._get_subclasses(cancers_uri, owl.default_world.as_rdflib_graph())
         for uri in tqdm(diseases, ncols=80, disable=self._silent):
             disease_class = do.search(iri=uri)[0]
             if disease_class.deprecated:
@@ -85,4 +89,7 @@ class DO(OWLBase):
                 "xrefs": xrefs,
                 "associated_with": associated_with,
             }
+
+            if uri in cancers:
+                disease["oncologic_disease"] = True
             self._load_disease(disease)

--- a/tests/unit/test_do.py
+++ b/tests/unit/test_do.py
@@ -28,6 +28,7 @@ def neuroblastoma():
             "umls:C0027819",
         ],
         aliases=[],
+        oncologic_disease=True,
     )
 
 
@@ -40,6 +41,7 @@ def pediatric_liposarcoma():
         xrefs=["ncit:C8091"],
         associated_with=["umls:C0279984"],
         aliases=["pediatric liposarcoma"],
+        oncologic_disease=True,
     )
 
 
@@ -52,6 +54,7 @@ def richter():
         aliases=["Richter syndrome"],
         xrefs=["ncit:C35424"],
         associated_with=["umls:C0349631", "gard:7578", "icd10.cm:C91.1"],
+        oncologic_disease=True,
     )
 
 


### PR DESCRIPTION
We're able to identify whether a disease is or relates to a cancer in some other sources. This adds the same property to DO terms.

* Use case is pretty narrow -- I'd like to slightly restrict exploration of the "inexact xrefs" issue (#244) to cancers for now, and I figured it made sense to just add the code to the library itself instead of keeping it in my analysis script