### PR TITLE
feat: add cancer filter to disease mapping dump

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -206,3 +206,10 @@ def test_get_term_mappings_merger(test_db: AbstractDatabase):
     ]
     diff = DeepDiff(fixture, results, ignore_order=True)
     assert diff == {}
+
+
+def test_get_term_mappings_cancer(test_db: AbstractDatabase):
+    results = list(
+        get_term_mappings(test_db, scope=RecordType.IDENTITY, cancer_only=True)
+    )
+    assert len(results) == 1


### PR DESCRIPTION
Add an option to filter mapping dump output to terms tagged with `oncologic_disease`.

I realized at the end that this doesn't help us with VarCat because we don't have this extracted from NCIt, but I figured we should still merge the work.